### PR TITLE
chore: flipped order of lint-staged and test for pre-commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "yarn test && lint-staged",
+      "pre-commit": "lint-staged && yarn test",
       "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
     }
   }


### PR DESCRIPTION
Just realised that test is now checking the linting of the code is correct before lint-staged got a
chance to fix it. Flipping the order should fix things without materially affecting the spirit of
this hook.