### PR TITLE
chore: v1.0.0

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "0.0.2",
+  "version": "1.0.0",
   "packages": ["packages/*"]
 }

--- a/packages/@postdfm/dfm2ast/package.json
+++ b/packages/@postdfm/dfm2ast/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@postdfm/dfm2ast",
-  "version": "0.0.2",
+  "version": "1.0.0",
   "description": "Convert Delphi Form files to an Abstract Syntax Tree",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/postdfm/package.json
+++ b/packages/postdfm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postdfm",
-  "version": "0.0.2",
+  "version": "1.0.0",
   "description": "Provides an API for easily transforming Delphi Forms",
   "main": "index.js",
   "keywords": [


### PR DESCRIPTION
affects: @postdfm/dfm2ast, postdfm

semantic-release takes care of actual versioning, but still would like to have the major version at
least be represented in git correctly