### PR TITLE
chore: revert --allow-same-version, revert @postdfm/ast version

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "format:check": "yarn prettier --check",
     "compile": "lerna run compile",
     "test": "jest --coverage",
-    "release": "lerna exec --concurrency 1 -- semantic-release -e semantic-release-monorepo --tag-format='${LERNA_PACKAGE_NAME}-v\\${version}' --repositoryUrl ssh://git@github.com/spiltcoffee/postdfm.git --allow-same-version"
+    "release": "lerna exec --concurrency 1 -- semantic-release -e semantic-release-monorepo --tag-format='${LERNA_PACKAGE_NAME}-v\\${version}' --repositoryUrl ssh://git@github.com/spiltcoffee/postdfm.git"
   },
   "devDependencies": {
     "@commitlint/config-conventional": "^7.5.0",

--- a/packages/@postdfm/ast/package.json
+++ b/packages/@postdfm/ast/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@postdfm/ast",
-  "version": "1.0.0",
+  "version": "0.0.1",
   "description": "Abstract Syntax Tree classes for postdfm",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/@postdfm/dfm2ast/package.json
+++ b/packages/@postdfm/dfm2ast/package.json
@@ -15,7 +15,7 @@
   },
   "homepage": "https://github.com/spiltcoffee/postdfm#readme",
   "dependencies": {
-    "@postdfm/ast": "^1.0.0",
+    "@postdfm/ast": "^0.0.1",
     "nearley": "^2.16.0"
   },
   "files": [


### PR DESCRIPTION
affects: @postdfm/ast

Giving up. I'll increment the version back to what it was once the @postdfm/ast-v1.0.0 tag exists