### PR TITLE
fix: fixed version numbers

### DIFF
--- a/packages/@postdfm/ast/package.json
+++ b/packages/@postdfm/ast/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@postdfm/ast",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "description": "Abstract Syntax Tree classes for postdfm",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/@postdfm/dfm2ast/package.json
+++ b/packages/@postdfm/dfm2ast/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@postdfm/dfm2ast",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Convert Delphi Form files to an Abstract Syntax Tree",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -15,7 +15,7 @@
   },
   "homepage": "https://github.com/spiltcoffee/postdfm#readme",
   "dependencies": {
-    "@postdfm/ast": "^0.0.1",
+    "@postdfm/ast": "^1.0.0",
     "nearley": "^2.16.0"
   },
   "files": [


### PR DESCRIPTION
affects: @postdfm/ast, @postdfm/dfm2ast

@postdfm/dfm2ast is pointing at the wrong version of @postdfm/ast