### PR TITLE
ci(greenkeeper): added @postdfm/ast

### DIFF
--- a/greenkeeper.json
+++ b/greenkeeper.json
@@ -3,6 +3,7 @@
     "default": {
       "packages": [
         "package.json",
+        "packages/@postdfm/ast/package.json",
         "packages/@postdfm/dfm2ast/package.json",
         "packages/postdfm/package.json"
       ]


### PR DESCRIPTION
no wildcard/glob support is available, so this is going to have to be part of adding new packages

fix #64