### PR TITLE
 fix(grammar): fixed multi line strings, variant lists

### DIFF
--- a/packages/@postdfm/ast/__test__/item.test.ts
+++ b/packages/@postdfm/ast/__test__/item.test.ts
@@ -10,7 +10,7 @@ describe("creating Items", () => {
   test("Item", () => {
     const propertyNode = new AST.Property(
       "Font.Name",
-      new AST.StringValue("sans-serif")
+      new AST.StringValue([new AST.LiteralString("sans-serif")])
     );
     const node = new AST.Item([propertyNode]);
 

--- a/packages/@postdfm/ast/__test__/list.test.ts
+++ b/packages/@postdfm/ast/__test__/list.test.ts
@@ -2,17 +2,25 @@ import * as AST from "../src";
 
 describe("creating Lists", () => {
   test("empty StringList", () => {
-    const node = new AST.StringList();
+    const node = new AST.VariantList();
 
     expect(node.values).toHaveLength(0);
   });
-  test("StringList", () => {
-    const node = new AST.StringList([
-      new AST.StringValue("hello"),
-      new AST.StringValue("world")
+  test("VariantList", () => {
+    const node = new AST.VariantList([
+      new AST.StringValue([new AST.LiteralString("hello")]),
+      new AST.IntegerValue(255),
+      new AST.BooleanValue(true),
+      new AST.StringValue([new AST.LiteralString("world")])
     ]);
 
-    expect(node.values).toContainEqual(new AST.StringValue("world"));
+    expect(node.values).toContainEqual(
+      new AST.StringValue([new AST.LiteralString("world")])
+    );
+
+    expect(node.values).toContainEqual(new AST.IntegerValue(255));
+
+    expect(node.values).toContainEqual(new AST.BooleanValue(true));
   });
   test("empty QualifiedList", () => {
     const node = new AST.IdentifierList();
@@ -35,7 +43,10 @@ describe("creating Lists", () => {
   test("ItemList", () => {
     const itemNode1 = new AST.Item();
     const itemNode2 = new AST.Item([
-      new AST.Property("Font.Name", new AST.StringValue("sans-serif"))
+      new AST.Property(
+        "Font.Name",
+        new AST.StringValue([new AST.LiteralString("sans-serif")])
+      )
     ]);
     const node = new AST.ItemList([itemNode1, itemNode2]);
 

--- a/packages/@postdfm/ast/__test__/object.test.ts
+++ b/packages/@postdfm/ast/__test__/object.test.ts
@@ -26,7 +26,7 @@ describe("creating FormObjects", () => {
   test("FormObject with properties", () => {
     const propertyNode = new AST.Property(
       "Font.Name",
-      new AST.StringValue("sans-serif")
+      new AST.StringValue([new AST.LiteralString("sans-serif")])
     );
 
     const node = new AST.DObject(
@@ -68,7 +68,7 @@ describe("creating FormObjects", () => {
   test("FormObject with a bit of everything", () => {
     const propertyNode = new AST.Property(
       "Font.Name",
-      new AST.StringValue("sans-serif")
+      new AST.StringValue([new AST.LiteralString("sans-serif")])
     );
 
     const childNode = new AST.DObject(AST.ObjectKind.Object, "MyEdit", "TEdit");

--- a/packages/@postdfm/ast/__test__/property.test.ts
+++ b/packages/@postdfm/ast/__test__/property.test.ts
@@ -2,7 +2,9 @@ import * as AST from "../src";
 
 describe("creating Properties", () => {
   test("Property with Value", () => {
-    const valueNode = new AST.StringValue("sans-serif");
+    const valueNode = new AST.StringValue([
+      new AST.LiteralString("sans-serif")
+    ]);
     const node = new AST.Property("Font.Name", valueNode);
 
     expect(node.name).toBe("Font.Name");
@@ -10,9 +12,9 @@ describe("creating Properties", () => {
   });
 
   test("Property with List", () => {
-    const listNode = new AST.StringList([
-      new AST.StringValue("Verdana"),
-      new AST.StringValue("sans-serif")
+    const listNode = new AST.VariantList([
+      new AST.StringValue([new AST.LiteralString("Verdana")]),
+      new AST.StringValue([new AST.LiteralString("sans-serif")])
     ]);
     const node = new AST.Property("Font.Name", listNode);
 

--- a/packages/@postdfm/ast/__test__/value.test.ts
+++ b/packages/@postdfm/ast/__test__/value.test.ts
@@ -1,14 +1,38 @@
 import * as AST from "../src";
 
 describe("creating Values", () => {
+  test("empty ControlString", () => {
+    const node = new AST.ControlString();
+    expect(node.value).toEqual("");
+  });
+
+  test("ControlString", () => {
+    const node = new AST.ControlString();
+    expect(node.value).toEqual("");
+  });
+
+  test("empty LiteralString", () => {
+    const node = new AST.LiteralString();
+    expect(node.value).toEqual("");
+  });
+
+  test("LiteralString", () => {
+    const node = new AST.LiteralString();
+    expect(node.value).toEqual("");
+  });
+
   test("empty StringValue", () => {
     const node = new AST.StringValue();
-    expect(node.value).toBe("");
+    expect(node.value).toEqual([]);
   });
 
   test("StringValue", () => {
-    const node = new AST.StringValue("hello world");
-    expect(node.value).toBe("hello world");
+    const node = new AST.StringValue([
+      new AST.LiteralString("hello"),
+      new AST.ControlString("\r\n"),
+      new AST.LiteralString("world")
+    ]);
+    expect(node.value).toContainEqual(new AST.LiteralString("world"));
   });
 
   test("empty HexStringValue", () => {

--- a/packages/@postdfm/ast/src/astType.ts
+++ b/packages/@postdfm/ast/src/astType.ts
@@ -1,5 +1,7 @@
 export enum ASTType {
   String = "string",
+  ControlString = "controlString",
+  LiteralString = "literalString",
   HexString = "hexString",
   Integer = "integer",
   Double = "double",

--- a/packages/@postdfm/ast/src/index.ts
+++ b/packages/@postdfm/ast/src/index.ts
@@ -5,6 +5,8 @@ export { Keywords } from "./keywords";
 
 export { Value } from "./value/value";
 export { StringValue } from "./value/stringValue";
+export { ControlString } from "./value/controlString";
+export { LiteralString } from "./value/literalString";
 export { HexStringValue } from "./value/hexStringValue";
 export { IntegerValue } from "./value/integerValue";
 export { DoubleValue } from "./value/doubleValue";
@@ -15,7 +17,7 @@ export { Item } from "./item";
 
 export { List } from "./list/list";
 export { IdentifierList } from "./list/identifierList";
-export { StringList } from "./list/stringList";
+export { VariantList } from "./list/variantList";
 export { ItemList } from "./list/itemList";
 
 export { Property } from "./property";

--- a/packages/@postdfm/ast/src/list/stringList.ts
+++ b/packages/@postdfm/ast/src/list/stringList.ts
@@ -1,9 +1,0 @@
-import { ASTType } from "../astType";
-import { StringValue } from "../value/stringValue";
-import { List } from "./list";
-
-export class StringList extends List<StringValue> {
-  constructor(values?: StringValue[]) {
-    super(ASTType.StringList, values || []);
-  }
-}

--- a/packages/@postdfm/ast/src/list/variantList.ts
+++ b/packages/@postdfm/ast/src/list/variantList.ts
@@ -1,0 +1,9 @@
+import { ASTType } from "../astType";
+import { Value } from "../value/value";
+import { List } from "./list";
+
+export class VariantList extends List<Value<any>> {
+  constructor(values?: Array<Value<any>>) {
+    super(ASTType.StringList, values || []);
+  }
+}

--- a/packages/@postdfm/ast/src/value/controlString.ts
+++ b/packages/@postdfm/ast/src/value/controlString.ts
@@ -1,0 +1,8 @@
+import { ASTType } from "../astType";
+import { StringValuePart } from "./stringValuePart";
+
+export class ControlString extends StringValuePart {
+  constructor(value?: string) {
+    super(ASTType.ControlString, value);
+  }
+}

--- a/packages/@postdfm/ast/src/value/literalString.ts
+++ b/packages/@postdfm/ast/src/value/literalString.ts
@@ -1,0 +1,8 @@
+import { ASTType } from "../astType";
+import { StringValuePart } from "./stringValuePart";
+
+export class LiteralString extends StringValuePart {
+  constructor(value?: string) {
+    super(ASTType.LiteralString, value);
+  }
+}

--- a/packages/@postdfm/ast/src/value/stringValue.ts
+++ b/packages/@postdfm/ast/src/value/stringValue.ts
@@ -1,8 +1,9 @@
 import { ASTType } from "../astType";
+import { StringValuePart } from "./stringValuePart";
 import { Value } from "./value";
 
-export class StringValue extends Value<string> {
-  constructor(value?: string) {
-    super(ASTType.String, value || "");
+export class StringValue extends Value<StringValuePart[]> {
+  constructor(value?: StringValuePart[]) {
+    super(ASTType.String, value || []);
   }
 }

--- a/packages/@postdfm/ast/src/value/stringValuePart.ts
+++ b/packages/@postdfm/ast/src/value/stringValuePart.ts
@@ -1,0 +1,8 @@
+import { ASTType } from "../astType";
+import { Value } from "./value";
+
+export class StringValuePart extends Value<string> {
+  constructor(astType: ASTType, value?: string) {
+    super(astType, value || "");
+  }
+}

--- a/packages/@postdfm/dfm2ast/__test__/everything/ast.json
+++ b/packages/@postdfm/dfm2ast/__test__/everything/ast.json
@@ -23,7 +23,10 @@
         "name": "Font.Name",
         "value": {
           "astType": "string",
-          "value": "MS Sans Serif"
+          "value": {
+            "astType": "literalString",
+            "value": "MS Sans Serif"
+          }
         },
         "raws": {
           "afterName": " ",
@@ -50,14 +53,14 @@
       {
         "astType": "property",
         "name": "Border.Bottom.Style",
-        "raws": {
-          "afterName": " ",
-          "before": "\r\n  ",
-          "beforeValue": " "
-        },
         "value": {
           "astType": "identifier",
           "value": "bdSolid"
+        },
+        "raws": {
+          "afterName": " ",
+          "beforeValue": " ",
+          "before": "\r\n  "
         }
       }
     ],
@@ -122,7 +125,53 @@
             "name": "Items.Strings",
             "value": {
               "astType": "stringList",
-              "values": "this is string.\r\nand another one...and another one...now with apostrophe '\u0000\u0000how fancy",
+              "values": [
+                {
+                  "astType": "string",
+                  "value": {
+                    "astType": "literalString",
+                    "value": "this is string."
+                  }
+                },
+                {
+                  "astType": "string",
+                  "value": [
+                    {
+                      "astType": "literalString",
+                      "value": "and another one..."
+                    },
+                    {
+                      "astType": "literalString",
+                      "value": "and another one...",
+                      "raws": {
+                        "before": "\r\n      + "
+                      }
+                    },
+                    {
+                      "astType": "literalString",
+                      "value": "now with apostrophe '",
+                      "raws": {
+                        "before": "\r\n      + "
+                      }
+                    },
+                    {
+                      "astType": "controlString",
+                      "value": "\u0000"
+                    },
+                    {
+                      "astType": "controlString",
+                      "value": "\u0000"
+                    },
+                    {
+                      "astType": "literalString",
+                      "value": "how fancy"
+                    }
+                  ],
+                  "raws": {
+                    "before": "\r\n        "
+                  }
+                }
+              ],
               "raws": {
                 "afterOpen": " ",
                 "beforeClose": "\r\n      "
@@ -452,6 +501,117 @@
               "beforeValue": " ",
               "before": "\r\n    "
             }
+          },
+          {
+            "astType": "property",
+            "name": "BackgroundColorStreamer",
+            "value": {
+              "astType": "stringList",
+              "values": [
+                {
+                  "astType": "integer",
+                  "value": "255"
+                },
+                {
+                  "astType": "integer",
+                  "value": "255",
+                  "raws": {
+                    "before": "\r\n      "
+                  }
+                },
+                {
+                  "astType": "integer",
+                  "value": "255",
+                  "raws": {
+                    "before": "\r\n      "
+                  }
+                },
+                {
+                  "astType": "boolean",
+                  "value": true,
+                  "raws": {
+                    "before": "\r\n      "
+                  }
+                }
+              ],
+              "raws": {
+                "afterOpen": "\r\n      ",
+                "beforeClose": ""
+              }
+            },
+            "raws": {
+              "afterName": " ",
+              "beforeValue": " ",
+              "before": "\r\n    "
+            }
+          }
+        ],
+        "children": [],
+        "raws": {
+          "afterName": "",
+          "beforeType": " ",
+          "beforeName": " ",
+          "beforeProperties": "\r\n    ",
+          "beforeEnd": "\r\n  ",
+          "before": "\r\n  "
+        }
+      },
+      {
+        "astType": "object",
+        "kind": "object",
+        "name": "Edit2",
+        "type": "TEdit",
+        "properties": [
+          {
+            "astType": "property",
+            "name": "Value",
+            "value": {
+              "astType": "string",
+              "value": [
+                {
+                  "astType": "literalString",
+                  "value": "Some multi line "
+                },
+                {
+                  "astType": "literalString",
+                  "value": "string",
+                  "raws": {
+                    "before": " +\r\n      "
+                  }
+                },
+                {
+                  "astType": "controlString",
+                  "value": "\u0000"
+                },
+                {
+                  "astType": "controlString",
+                  "value": "\u0000"
+                },
+                {
+                  "astType": "controlString",
+                  "value": "\u0000",
+                  "raws": {
+                    "before": " +\r\n      "
+                  }
+                },
+                {
+                  "astType": "literalString",
+                  "value": "hello"
+                },
+                {
+                  "astType": "controlString",
+                  "value": "\u0000"
+                },
+                {
+                  "astType": "literalString",
+                  "value": "world"
+                }
+              ]
+            },
+            "raws": {
+              "afterName": " ",
+              "beforeValue": "\r\n      "
+            }
           }
         ],
         "children": [],
@@ -482,7 +642,10 @@
                 "name": "Value",
                 "value": {
                   "astType": "string",
-                  "value": ""
+                  "value": {
+                    "astType": "literalString",
+                    "value": ""
+                  }
                 },
                 "raws": {
                   "afterName": " ",

--- a/packages/@postdfm/dfm2ast/__test__/everything/form.dfm
+++ b/packages/@postdfm/dfm2ast/__test__/everything/form.dfm
@@ -44,6 +44,11 @@ object Form1: TForm1
       255
       True)
   end
+  object Edit2: TEdit
+    Value =
+      'Some multi line ' +
+      'string'#13#10 +
+      #37'hello'#45'world'
   object SubForm: TForm2
     inline SubEdit: TEdit
       Value = ''

--- a/packages/@postdfm/dfm2ast/__test__/everything/form.dfm
+++ b/packages/@postdfm/dfm2ast/__test__/everything/form.dfm
@@ -38,6 +38,11 @@ object Form1: TForm1
     MinLength = -20e1
     SomeOtherLength = 45.333e20
     Color = $FF0000
+    BackgroundColorStreamer = (
+      255
+      255
+      255
+      True)
   end
   object SubForm: TForm2
     inline SubEdit: TEdit

--- a/packages/@postdfm/dfm2ast/__test__/everything/form.dfm
+++ b/packages/@postdfm/dfm2ast/__test__/everything/form.dfm
@@ -49,6 +49,7 @@ object Form1: TForm1
       'Some multi line ' +
       'string'#13#10 +
       #37'hello'#45'world'
+  end
   object SubForm: TForm2
     inline SubEdit: TEdit
       Value = ''

--- a/packages/@postdfm/dfm2ast/ne/list.ne
+++ b/packages/@postdfm/dfm2ast/ne/list.ne
@@ -9,16 +9,14 @@ commaValues -> commaValues _ "," _ value
   return [].concat(values, value);
 }%}
 
-plusValues -> string
-{% ([v]) => v.value %}
+variantValues -> value
+{% ([value]) => [value] %}
 
-# plus implies string on sameline
-plusValues -> plusValues _ "+" _ string
-{% ([left, _, __, ___, right]) => `${left}${right.value}` %}
-
-# space implies string on newline
-plusValues -> plusValues __ string
-{% ([left, _, right]) => `${left}\r\n${right.value}` %}
+variantValues -> variantValues __ value
+{% ([values, before, value]) => {
+  value.raws = { ...(values.raws || {}), before };
+  return [].concat(values, value);
+} %}
 
 hexValues -> hexString
 {% id %}
@@ -49,16 +47,16 @@ identifierList -> "[" _ commaValues _ "]"
   return node;
 } %}
 
-stringList -> "(" _ ")"
+variantList -> "(" _ ")"
 {% ([_, beforeClose]) => {
-  const node = new AST.StringList();
+  const node = new AST.VariantList();
   node.raws = { beforeClose };
   return node;
 } %}
 
-stringList -> "(" _ plusValues _ ")"
-{% ([_, afterOpen, plusValues, beforeClose]) => {
-  const node = new AST.StringList(plusValues);
+variantList -> "(" _ variantValues _ ")"
+{% ([_, afterOpen, variantValues, beforeClose]) => {
+  const node = new AST.VariantList(variantValues);
   node.raws = { afterOpen, beforeClose };
   return node;
 } %}

--- a/packages/@postdfm/dfm2ast/ne/value.ne
+++ b/packages/@postdfm/dfm2ast/ne/value.ne
@@ -8,7 +8,7 @@ value -> double
 {% ([value]) => new AST.DoubleValue(value) %}
 
 value -> string
-{% ([valueObject]) => new AST.StringValue(valueObject.value) %}
+{% ([value]) => new AST.StringValue(value) %}
 
 value -> identifer
 {% ([value], _, reject) => {
@@ -22,7 +22,7 @@ value -> identifer
 value -> identifierList
 {% id %}
 
-value -> stringList
+value -> variantList
 {% id %}
 
 value -> hexStringList


### PR DESCRIPTION
- StringList was changed to VariantList
- Strings now carry raws on their nodes, and are separated
as Control and Literal strings

BREAKING CHANGE: StringList -> VariantList

fix #80, fix #81

---

test(grammar): added failing test for multiline string

---

test(grammar): added failing test for variant list