### PR TITLE
fix(@postdfm/dfm2ast): fixed parser to interpret nameless object correctly

### DIFF
--- a/__test__/__fixtures__/parse/boundary-keyword/ast.json
+++ b/__test__/__fixtures__/parse/boundary-keyword/ast.json
@@ -37,7 +37,7 @@
             "raws": {
               "afterName": "",
               "beforeType": " ",
-              "beforeName": " ",
+              "beforeDef": " ",
               "beforeEnd": "\r\n    "
             }
           }
@@ -45,7 +45,7 @@
         "raws": {
           "afterName": "",
           "beforeType": " ",
-          "beforeName": " ",
+          "beforeDef": " ",
           "beforeProperties": "\r\n    ",
           "beforeChildren": "\r\n    ",
           "beforeEnd": "\r\n  "
@@ -55,7 +55,7 @@
     "raws": {
       "afterName": "",
       "beforeType": " ",
-      "beforeName": " ",
+      "beforeDef": " ",
       "beforeChildren": "\r\n  ",
       "beforeEnd": "\r\n"
     }

--- a/__test__/__fixtures__/parse/empty-object/ast.json
+++ b/__test__/__fixtures__/parse/empty-object/ast.json
@@ -9,7 +9,7 @@
     "raws": {
       "afterName": "",
       "beforeEnd": "\r\n",
-      "beforeName": " ",
+      "beforeDef": " ",
       "beforeType": " "
     },
     "type": "TEmpty"

--- a/__test__/__fixtures__/parse/everything/ast.json
+++ b/__test__/__fixtures__/parse/everything/ast.json
@@ -122,7 +122,7 @@
         "raws": {
           "afterName": "",
           "beforeType": " ",
-          "beforeName": " ",
+          "beforeDef": " ",
           "beforeProperties": "\r\n    ",
           "beforeEnd": "\r\n  "
         }
@@ -222,7 +222,7 @@
           "afterType": " ",
           "beforeOrder": "",
           "afterOrder": "",
-          "beforeName": " ",
+          "beforeDef": " ",
           "beforeProperties": "\r\n    ",
           "beforeEnd": "\r\n  ",
           "before": "\r\n  "
@@ -453,7 +453,7 @@
         "raws": {
           "afterName": "",
           "beforeType": " ",
-          "beforeName": " ",
+          "beforeDef": " ",
           "beforeProperties": "\r\n    ",
           "beforeEnd": "\r\n  ",
           "before": "\r\n  "
@@ -574,7 +574,7 @@
         "raws": {
           "afterName": "",
           "beforeType": " ",
-          "beforeName": " ",
+          "beforeDef": " ",
           "beforeProperties": "\r\n    ",
           "beforeEnd": "\r\n  ",
           "before": "\r\n  "
@@ -651,7 +651,7 @@
         "raws": {
           "afterName": "",
           "beforeType": " ",
-          "beforeName": " ",
+          "beforeDef": " ",
           "beforeProperties": "\r\n    ",
           "beforeEnd": "\r\n  ",
           "before": "\r\n  "
@@ -719,7 +719,7 @@
         "raws": {
           "afterName": "",
           "beforeType": " ",
-          "beforeName": " ",
+          "beforeDef": " ",
           "beforeProperties": "\r\n    ",
           "beforeEnd": "\r\n  ",
           "before": "\r\n  "
@@ -773,7 +773,7 @@
             "raws": {
               "afterName": "",
               "beforeType": " ",
-              "beforeName": " ",
+              "beforeDef": " ",
               "beforeProperties": "\r\n      ",
               "beforeEnd": "\r\n    "
             }
@@ -782,7 +782,7 @@
         "raws": {
           "afterName": "",
           "beforeType": " ",
-          "beforeName": " ",
+          "beforeDef": " ",
           "beforeChildren": "\r\n    ",
           "beforeEnd": "\r\n  ",
           "before": "\r\n  "
@@ -798,7 +798,19 @@
         "raws": {
           "afterName": "",
           "beforeType": " ",
-          "beforeName": " ",
+          "beforeDef": " ",
+          "beforeEnd": "\r\n  ",
+          "before": "\r\n  "
+        }
+      },
+      {
+        "astType": "object",
+        "kind": "object",
+        "type": "TNameless",
+        "properties": [],
+        "children": [],
+        "raws": {
+          "beforeDef": " ",
           "beforeEnd": "\r\n  ",
           "before": "\r\n  "
         }
@@ -807,7 +819,7 @@
     "raws": {
       "afterName": "",
       "beforeType": " ",
-      "beforeName": " ",
+      "beforeDef": " ",
       "beforeProperties": "\r\n  ",
       "beforeChildren": "\r\n  ",
       "beforeEnd": "\r\n"

--- a/__test__/__fixtures__/parse/everything/form.dfm
+++ b/__test__/__fixtures__/parse/everything/form.dfm
@@ -66,4 +66,6 @@ object Form1: TForm1
   end
   object Nothing: _TNothing
   end
+  object TNameless
+  end
 end

--- a/__test__/__fixtures__/parse/lists/ast.json
+++ b/__test__/__fixtures__/parse/lists/ast.json
@@ -415,7 +415,7 @@
     "raws": {
       "afterName": "",
       "beforeEnd": "\r\n",
-      "beforeName": " ",
+      "beforeDef": " ",
       "beforeProperties": "\r\n  ",
       "beforeType": " "
     },

--- a/__test__/__fixtures__/parse/no-type/ast.json
+++ b/__test__/__fixtures__/parse/no-type/ast.json
@@ -4,11 +4,11 @@
     "astType": "object",
     "children": [],
     "kind": "object",
-    "name": "Empty",
+    "type": "TEmpty",
     "properties": [],
     "raws": {
       "beforeEnd": "\r\n",
-      "beforeName": " "
+      "beforeDef": " "
     }
   },
   "raws": {

--- a/__test__/__fixtures__/parse/no-type/form.dfm
+++ b/__test__/__fixtures__/parse/no-type/form.dfm
@@ -1,2 +1,2 @@
-object Empty
+object TEmpty
 end

--- a/__test__/__fixtures__/parse/objects/ast.json
+++ b/__test__/__fixtures__/parse/objects/ast.json
@@ -12,7 +12,7 @@
         "raws": {
           "afterName": "",
           "beforeEnd": "\r\n  ",
-          "beforeName": " ",
+          "beforeDef": " ",
           "beforeType": " "
         },
         "type": "TEdit"
@@ -27,7 +27,7 @@
           "afterName": "",
           "before": "\r\n  ",
           "beforeEnd": "\r\n  ",
-          "beforeName": " ",
+          "beforeDef": " ",
           "beforeType": " "
         },
         "type": "TEdit"
@@ -42,10 +42,22 @@
           "afterName": "",
           "before": "\r\n  ",
           "beforeEnd": "\r\n  ",
-          "beforeName": " ",
+          "beforeDef": " ",
           "beforeType": " "
         },
         "type": "TEdit"
+      },
+      {
+        "astType": "object",
+        "children": [],
+        "kind": "object",
+        "type": "TNameless",
+        "properties": [],
+        "raws": {
+          "before": "\r\n  ",
+          "beforeEnd": "\r\n  ",
+          "beforeDef": " "
+        }
       },
       {
         "astType": "object",
@@ -86,7 +98,7 @@
                                                 "raws": {
                                                   "afterName": "",
                                                   "beforeEnd": "\r\n                      ",
-                                                  "beforeName": " ",
+                                                  "beforeDef": " ",
                                                   "beforeType": " "
                                                 },
                                                 "type": "TComponent"
@@ -99,7 +111,7 @@
                                               "afterName": "",
                                               "beforeChildren": "\r\n                      ",
                                               "beforeEnd": "\r\n                    ",
-                                              "beforeName": " ",
+                                              "beforeDef": " ",
                                               "beforeType": " "
                                             },
                                             "type": "TComponent"
@@ -112,7 +124,7 @@
                                           "afterName": "",
                                           "beforeChildren": "\r\n                    ",
                                           "beforeEnd": "\r\n                  ",
-                                          "beforeName": " ",
+                                          "beforeDef": " ",
                                           "beforeType": " "
                                         },
                                         "type": "TComponent"
@@ -125,7 +137,7 @@
                                       "afterName": "",
                                       "beforeChildren": "\r\n                  ",
                                       "beforeEnd": "\r\n                ",
-                                      "beforeName": " ",
+                                      "beforeDef": " ",
                                       "beforeType": " "
                                     },
                                     "type": "TComponent"
@@ -138,7 +150,7 @@
                                   "afterName": "",
                                   "beforeChildren": "\r\n                ",
                                   "beforeEnd": "\r\n              ",
-                                  "beforeName": " ",
+                                  "beforeDef": " ",
                                   "beforeType": " "
                                 },
                                 "type": "TComponent"
@@ -151,7 +163,7 @@
                               "afterName": "",
                               "beforeChildren": "\r\n              ",
                               "beforeEnd": "\r\n            ",
-                              "beforeName": " ",
+                              "beforeDef": " ",
                               "beforeType": " "
                             },
                             "type": "TComponent"
@@ -164,7 +176,7 @@
                           "afterName": "",
                           "beforeChildren": "\r\n            ",
                           "beforeEnd": "\r\n          ",
-                          "beforeName": " ",
+                          "beforeDef": " ",
                           "beforeType": " "
                         },
                         "type": "TComponent"
@@ -177,7 +189,7 @@
                       "afterName": "",
                       "beforeChildren": "\r\n          ",
                       "beforeEnd": "\r\n        ",
-                      "beforeName": " ",
+                      "beforeDef": " ",
                       "beforeType": " "
                     },
                     "type": "TComponent"
@@ -190,7 +202,7 @@
                   "afterName": "",
                   "beforeChildren": "\r\n        ",
                   "beforeEnd": "\r\n      ",
-                  "beforeName": " ",
+                  "beforeDef": " ",
                   "beforeType": " "
                 },
                 "type": "TComponent"
@@ -203,7 +215,7 @@
               "afterName": "",
               "beforeChildren": "\r\n      ",
               "beforeEnd": "\r\n    ",
-              "beforeName": " ",
+              "beforeDef": " ",
               "beforeType": " "
             },
             "type": "TComponent"
@@ -217,7 +229,7 @@
           "before": "\r\n  ",
           "beforeChildren": "\r\n    ",
           "beforeEnd": "\r\n  ",
-          "beforeName": " ",
+          "beforeDef": " ",
           "beforeType": " "
         },
         "type": "_TUnder_Score"
@@ -248,7 +260,7 @@
       "afterName": "",
       "beforeChildren": "\r\n  ",
       "beforeEnd": "\r\n",
-      "beforeName": " ",
+      "beforeDef": " ",
       "beforeProperties": "\r\n  ",
       "beforeType": " "
     },

--- a/__test__/__fixtures__/parse/objects/form.dfm
+++ b/__test__/__fixtures__/parse/objects/form.dfm
@@ -6,6 +6,8 @@ object BasicForm: TForm
   end
   inherited Edit3: TEdit
   end
+  object TNameless
+  end
   object _Under_Score: _TUnder_Score
     object DeepTree1: TComponent
       object DeepTree2: TComponent

--- a/__test__/__fixtures__/parse/properties/ast.json
+++ b/__test__/__fixtures__/parse/properties/ast.json
@@ -306,8 +306,8 @@
     ],
     "raws": {
       "afterName": "",
+      "beforeDef": " ",
       "beforeEnd": "\r\n",
-      "beforeName": " ",
       "beforeProperties": "\r\n  ",
       "beforeType": " "
     },

--- a/__test__/__fixtures__/parse/strings/ast.json
+++ b/__test__/__fixtures__/parse/strings/ast.json
@@ -150,8 +150,8 @@
     ],
     "raws": {
       "afterName": "",
+      "beforeDef": " ",
       "beforeEnd": "\r\n",
-      "beforeName": " ",
       "beforeProperties": "\r\n  ",
       "beforeType": " "
     },

--- a/__test__/__fixtures__/parse/weird-spacing/ast.json
+++ b/__test__/__fixtures__/parse/weird-spacing/ast.json
@@ -56,8 +56,8 @@
         ],
         "raws": {
           "afterName": "",
+          "beforeDef": " ",
           "beforeEnd": "\r\n  ",
-          "beforeName": " ",
           "beforeProperties": "\r\n    ",
           "beforeType": " "
         },
@@ -156,8 +156,8 @@
           "afterOrder": "",
           "afterType": " ",
           "before": "\r\n\r\n  ",
+          "beforeDef": " ",
           "beforeEnd": "\r\n  ",
-          "beforeName": " ",
           "beforeOrder": "",
           "beforeProperties": "\r\n\r\n                         ",
           "beforeType": " "
@@ -388,8 +388,8 @@
         "raws": {
           "afterName": "",
           "before": "\r\n  ",
+          "beforeDef": " ",
           "beforeEnd": "\r\n  ",
-          "beforeName": " ",
           "beforeProperties": "\r\n    ",
           "beforeType": " "
         },
@@ -509,8 +509,8 @@
         "raws": {
           "afterName": "",
           "before": "\r\n  ",
+          "beforeDef": " ",
           "beforeEnd": "\r\n  ",
-          "beforeName": " ",
           "beforeProperties": "\r\n    ",
           "beforeType": " "
         },
@@ -588,8 +588,8 @@
         "raws": {
           "afterName": "",
           "before": "\r\n  ",
+          "beforeDef": " ",
           "beforeEnd": " ",
-          "beforeName": " ",
           "beforeProperties": " ",
           "beforeType": " "
         },
@@ -656,8 +656,8 @@
         "raws": {
           "afterName": "",
           "before": "\r\n  ",
+          "beforeDef": " ",
           "beforeEnd": "\r\n  ",
-          "beforeName": " ",
           "beforeProperties": "\r\n\r\n\r\n    ",
           "beforeType": " "
         },
@@ -705,8 +705,8 @@
             ],
             "raws": {
               "afterName": "",
+              "beforeDef": " ",
               "beforeEnd": "\r\n",
-              "beforeName": " ",
               "beforeProperties": "\r\n",
               "beforeType": " "
             },
@@ -720,8 +720,8 @@
           "afterName": "",
           "before": "\r\n",
           "beforeChildren": "\r\n",
+          "beforeDef": " ",
           "beforeEnd": "\r\n",
-          "beforeName": " ",
           "beforeType": " "
         },
         "type": "TForm2"
@@ -735,8 +735,8 @@
         "raws": {
           "afterName": "",
           "before": "\r\n",
+          "beforeDef": " ",
           "beforeEnd": "\r\n",
-          "beforeName": " ",
           "beforeType": " "
         },
         "type": "_TNothing"
@@ -808,8 +808,8 @@
     "raws": {
       "afterName": "",
       "beforeChildren": "   ",
+      "beforeDef": "\r\n\r\n\r\n\r\n  ",
       "beforeEnd": "\r\n",
-      "beforeName": "\r\n\r\n\r\n\r\n  ",
       "beforeProperties": "\r\n  ",
       "beforeType": " "
     },

--- a/__test__/__fixtures__/transform/everything/cis.json
+++ b/__test__/__fixtures__/transform/everything/cis.json
@@ -122,7 +122,7 @@
         "raws": {
           "afterName": "",
           "beforeType": " ",
-          "beforeName": " ",
+          "beforeDef": " ",
           "beforeProperties": "\r\n    ",
           "beforeEnd": "\r\n  "
         }
@@ -222,7 +222,7 @@
           "afterType": " ",
           "beforeOrder": "",
           "afterOrder": "",
-          "beforeName": " ",
+          "beforeDef": " ",
           "beforeProperties": "\r\n    ",
           "beforeEnd": "\r\n  ",
           "before": "\r\n  "
@@ -453,7 +453,7 @@
         "raws": {
           "afterName": "",
           "beforeType": " ",
-          "beforeName": " ",
+          "beforeDef": " ",
           "beforeProperties": "\r\n    ",
           "beforeEnd": "\r\n  ",
           "before": "\r\n  "
@@ -574,7 +574,7 @@
         "raws": {
           "afterName": "",
           "beforeType": " ",
-          "beforeName": " ",
+          "beforeDef": " ",
           "beforeProperties": "\r\n    ",
           "beforeEnd": "\r\n  ",
           "before": "\r\n  "
@@ -651,7 +651,7 @@
         "raws": {
           "afterName": "",
           "beforeType": " ",
-          "beforeName": " ",
+          "beforeDef": " ",
           "beforeProperties": "\r\n    ",
           "beforeEnd": "\r\n  ",
           "before": "\r\n  "
@@ -719,7 +719,7 @@
         "raws": {
           "afterName": "",
           "beforeType": " ",
-          "beforeName": " ",
+          "beforeDef": " ",
           "beforeProperties": "\r\n    ",
           "beforeEnd": "\r\n  ",
           "before": "\r\n  "
@@ -773,7 +773,7 @@
             "raws": {
               "afterName": "",
               "beforeType": " ",
-              "beforeName": " ",
+              "beforeDef": " ",
               "beforeProperties": "\r\n      ",
               "beforeEnd": "\r\n    "
             }
@@ -782,7 +782,7 @@
         "raws": {
           "afterName": "",
           "beforeType": " ",
-          "beforeName": " ",
+          "beforeDef": " ",
           "beforeChildren": "\r\n    ",
           "beforeEnd": "\r\n  ",
           "before": "\r\n  "
@@ -798,7 +798,7 @@
         "raws": {
           "afterName": "",
           "beforeType": " ",
-          "beforeName": " ",
+          "beforeDef": " ",
           "beforeEnd": "\r\n  ",
           "before": "\r\n  "
         }
@@ -807,7 +807,7 @@
     "raws": {
       "afterName": "",
       "beforeType": " ",
-      "beforeName": " ",
+      "beforeDef": " ",
       "beforeProperties": "\r\n  ",
       "beforeChildren": "\r\n  ",
       "beforeEnd": "\r\n"

--- a/__test__/__fixtures__/transform/everything/trans.json
+++ b/__test__/__fixtures__/transform/everything/trans.json
@@ -122,7 +122,7 @@
         "raws": {
           "afterName": "",
           "beforeType": " ",
-          "beforeName": " ",
+          "beforeDef": " ",
           "beforeProperties": "\r\n    ",
           "beforeEnd": "\r\n  "
         }
@@ -222,7 +222,7 @@
           "afterType": " ",
           "beforeOrder": "",
           "afterOrder": "",
-          "beforeName": " ",
+          "beforeDef": " ",
           "beforeProperties": "\r\n    ",
           "beforeEnd": "\r\n  ",
           "before": "\r\n  "
@@ -453,7 +453,7 @@
         "raws": {
           "afterName": "",
           "beforeType": " ",
-          "beforeName": " ",
+          "beforeDef": " ",
           "beforeProperties": "\r\n    ",
           "beforeEnd": "\r\n  ",
           "before": "\r\n  "
@@ -574,7 +574,7 @@
         "raws": {
           "afterName": "",
           "beforeType": " ",
-          "beforeName": " ",
+          "beforeDef": " ",
           "beforeProperties": "\r\n    ",
           "beforeEnd": "\r\n  ",
           "before": "\r\n  "
@@ -651,7 +651,7 @@
         "raws": {
           "afterName": "",
           "beforeType": " ",
-          "beforeName": " ",
+          "beforeDef": " ",
           "beforeProperties": "\r\n    ",
           "beforeEnd": "\r\n  ",
           "before": "\r\n  "
@@ -719,7 +719,7 @@
         "raws": {
           "afterName": "",
           "beforeType": " ",
-          "beforeName": " ",
+          "beforeDef": " ",
           "beforeProperties": "\r\n    ",
           "beforeEnd": "\r\n  ",
           "before": "\r\n  "
@@ -773,7 +773,7 @@
             "raws": {
               "afterName": "",
               "beforeType": " ",
-              "beforeName": " ",
+              "beforeDef": " ",
               "beforeProperties": "\r\n      ",
               "beforeEnd": "\r\n    "
             }
@@ -782,7 +782,7 @@
         "raws": {
           "afterName": "",
           "beforeType": " ",
-          "beforeName": " ",
+          "beforeDef": " ",
           "beforeChildren": "\r\n    ",
           "beforeEnd": "\r\n  ",
           "before": "\r\n  "
@@ -798,7 +798,7 @@
         "raws": {
           "afterName": "",
           "beforeType": " ",
-          "beforeName": " ",
+          "beforeDef": " ",
           "beforeEnd": "\r\n  ",
           "before": "\r\n  "
         }
@@ -807,7 +807,7 @@
     "raws": {
       "afterName": "",
       "beforeType": " ",
-      "beforeName": " ",
+      "beforeDef": " ",
       "beforeProperties": "\r\n  ",
       "beforeChildren": "\r\n  ",
       "beforeEnd": "\r\n"

--- a/__test__/__fixtures__/transform/hello-world/cis.json
+++ b/__test__/__fixtures__/transform/hello-world/cis.json
@@ -25,7 +25,7 @@
     ],
     "children": [],
     "raws": {
-      "beforeName": " ",
+      "beforeDef": " ",
       "beforeProperties": "\r\n  ",
       "beforeEnd": "\r\n"
     }

--- a/__test__/__fixtures__/transform/hello-world/trans.json
+++ b/__test__/__fixtures__/transform/hello-world/trans.json
@@ -25,7 +25,7 @@
     ],
     "children": [],
     "raws": {
-      "beforeName": " ",
+      "beforeDef": " ",
       "beforeProperties": "\r\n  ",
       "beforeEnd": "\r\n"
     }

--- a/packages/@postdfm/ast/src/object.ts
+++ b/packages/@postdfm/ast/src/object.ts
@@ -5,7 +5,7 @@ import { ObjectKind } from "./objectKind";
 import { Property } from "./property";
 
 interface ObjectRaws extends ASTRaws {
-  beforeName?: string;
+  beforeDef?: string;
   afterName?: string;
   beforeType?: string;
   afterType?: string;

--- a/packages/@postdfm/ast2dfm/__test__/fixtures/index.test.ts
+++ b/packages/@postdfm/ast2dfm/__test__/fixtures/index.test.ts
@@ -7,7 +7,7 @@ const rootFixturesDir = path.join("__test__", "__fixtures__");
 const parseFixturesDir = path.join(rootFixturesDir, "parse");
 
 describe("dfm2ast", () => {
-  describe("fixtures", () => {
+  describe("parse fixtures", () => {
     const fixtures = fs.readdirSync(parseFixturesDir);
     fixtures.forEach((fixture) => {
       const astFile = path.join(parseFixturesDir, fixture, "ast.json");

--- a/packages/@postdfm/ast2dfm/src/stringifier.ts
+++ b/packages/@postdfm/ast2dfm/src/stringifier.ts
@@ -229,12 +229,13 @@ export default class Stringifier {
     return this.print(
       raws.before,
       ast.kind,
-      raws.beforeName,
+      raws.beforeDef,
       ast.name,
       raws.afterName,
-      ast.type
-        ? this.print(":", raws.beforeType, ast.type, raws.afterType)
-        : "",
+      ast.name ? ":" : "",
+      raws.beforeType,
+      ast.type,
+      raws.afterType,
       ast.order !== undefined
         ? this.print(
             "[",

--- a/packages/@postdfm/dfm2ast/__test__/fixtures/index.test.ts
+++ b/packages/@postdfm/dfm2ast/__test__/fixtures/index.test.ts
@@ -6,7 +6,7 @@ const rootFixturesDir = path.join("__test__", "__fixtures__");
 const parseFixturesDir = path.join(rootFixturesDir, "parse");
 
 describe("dfm2ast", () => {
-  describe("fixtures", () => {
+  describe("parse fixtures", () => {
     const fixtures = fs.readdirSync(parseFixturesDir);
     fixtures.forEach((fixture) => {
       const formFile = path.join(parseFixturesDir, fixture, "form.dfm");

--- a/packages/@postdfm/dfm2ast/ne/object.ne
+++ b/packages/@postdfm/dfm2ast/ne/object.ne
@@ -1,28 +1,28 @@
 object -> objectKind _ objectDef __ "end"i
-{% ([kind, beforeName, { name, type, order, raws: defRaws }, beforeEnd]) => {
+{% ([kind, beforeDef, { name, type, order, raws: defRaws }, beforeEnd]) => {
   const node = new AST.DObject(kind, name, type, order);
-  node.raws = { ...(defRaws || {}), beforeName, beforeEnd };
+  node.raws = { ...(defRaws || {}), beforeDef, beforeEnd };
   return node;
 } %}
 
 object -> objectKind _ objectDef _ properties __ "end"i
-{% ([kind, beforeName, { name, type, order, raws: defRaws }, beforeProperties, properties, beforeEnd]) => {
+{% ([kind, beforeDef, { name, type, order, raws: defRaws }, beforeProperties, properties, beforeEnd]) => {
   const node = new AST.DObject(kind, name, type, order, properties)
-  node.raws = { ...(defRaws || {}), beforeName, beforeProperties, beforeEnd };
+  node.raws = { ...(defRaws || {}), beforeDef, beforeProperties, beforeEnd };
   return node;
 } %}
 
 object -> objectKind _ objectDef _ objects __ "end"i
-{% ([kind, beforeName, { name, type, order, raws: defRaws }, beforeChildren, children, beforeEnd]) => {
+{% ([kind, beforeDef, { name, type, order, raws: defRaws }, beforeChildren, children, beforeEnd]) => {
   const node = new AST.DObject(kind, name, type, order, undefined, children);
-  node.raws = { ...(defRaws || {}), beforeName, beforeChildren, beforeEnd };
+  node.raws = { ...(defRaws || {}), beforeDef, beforeChildren, beforeEnd };
   return node;
 } %}
 
 object -> objectKind _ objectDef _ properties _ objects __ "end"i
-{% ([kind, beforeName, { name, type, order, raws: defRaws }, beforeProperties, properties, beforeChildren, children, beforeEnd]) => {
+{% ([kind, beforeDef, { name, type, order, raws: defRaws }, beforeProperties, properties, beforeChildren, children, beforeEnd]) => {
   const node = new AST.DObject(kind, name, type, order, properties, children);
-  node.raws = { ...(defRaws || {}), beforeName, beforeProperties, beforeChildren, beforeEnd };
+  node.raws = { ...(defRaws || {}), beforeDef, beforeProperties, beforeChildren, beforeEnd };
   return node;
 } %}
 
@@ -34,7 +34,7 @@ objectKind -> "object"i
 {% () => AST.ObjectKind.Object %}
 
 objectDef -> identifer
-{% ([name]) => ({ name }) %}
+{% ([type]) => ({ type }) %}
 
 objectDef -> identifer _ ":" _ identifer
 {% ([name, afterName, _, beforeType, type]) => ({
@@ -48,11 +48,11 @@ objectDef -> identifer _ ":" _ identifer
 
 #is this one valid?
 objectDef -> identifer _ "[" _ decimal _ "]"
-{% ([name, afterName, _, beforeOrder, order, afterOrder]) => ({
-  name,
+{% ([type, afterType, _, beforeOrder, order, afterOrder]) => ({
+  type,
   order,
   raws: {
-    afterName,
+    afterType,
     beforeOrder,
     afterOrder
   }


### PR DESCRIPTION
### What issues is this pull request related to?
fix #180

### What changes were made in this pull request?
Nameless objects were incorrectly being interpreted as having a name and no type, rather than a type
and no name

BREAKING CHANGE: Nameless objects will now define the type and leave the name undefined
