### PR TITLE
fix(@postdfm/dfm2ast): concat to existing array rather than constructing new one

### DIFF
--- a/packages/@postdfm/dfm2ast/ne/list.ne
+++ b/packages/@postdfm/dfm2ast/ne/list.ne
@@ -6,7 +6,7 @@ commaValues -> commaValues _ "," _ value
   const prevValue = values[values.length - 1];
   prevValue.raws = { ...(prevValue.raws || {}), after };
   value.raws = { ...(value.raws || {}), before };
-  return [].concat(values, value);
+  return values.concat(value);
 }%}
 
 variantValues -> value
@@ -15,7 +15,7 @@ variantValues -> value
 variantValues -> variantValues __ value
 {% ([values, before, value]) => {
   value.raws = { ...(values.raws || {}), before };
-  return [].concat(values, value);
+  return values.concat(value);
 } %}
 
 binaryValues -> binaryString
@@ -24,7 +24,7 @@ binaryValues -> binaryString
 binaryValues -> binaryValues __ binaryString
 {% ([values, before, value]) => {
   value.raws = { ...(value.raws || {}), before };
-  return [].concat(values, value);
+  return values.concat(value);
 }%}
 
 itemValues -> item
@@ -33,7 +33,7 @@ itemValues -> item
 itemValues -> itemValues _ item
 {% ([items, before, item]) => {
   item.raws = { ...(item.raws || {}), before };
-  return [].concat(items, item);
+  return items.concat(item);
 } %}
 
 identifierList -> "[" _ "]"

--- a/packages/@postdfm/dfm2ast/ne/object.ne
+++ b/packages/@postdfm/dfm2ast/ne/object.ne
@@ -81,5 +81,5 @@ objects -> objects __ object
     ...(object.raws || {}),
     before
   };
-  return [].concat(objects, object);
+  return objects.concat(object);
 } %}

--- a/packages/@postdfm/dfm2ast/ne/primitive.ne
+++ b/packages/@postdfm/dfm2ast/ne/primitive.ne
@@ -30,7 +30,7 @@ string -> string singleString
     prevValue.value += "'" + value.value;
     return values;
   } else {
-    return [].concat(values, value)
+    return values.concat(value)
   }
 } %}
 
@@ -40,7 +40,7 @@ stringSep -> _ "+" _
 string -> string stringSep singleString
 {% ([values, before, value]) => {
   value.raws = { ...(value.raws || {}), before };
-  return [].concat(values, value);
+  return values.concat(value);
 } %}
 
 singleString -> controlChar

--- a/packages/@postdfm/dfm2ast/ne/property.ne
+++ b/packages/@postdfm/dfm2ast/ne/property.ne
@@ -1,10 +1,10 @@
 properties -> property
-{% properties => properties %}
+{% ([property]) => [property] %}
 
 properties -> properties _ property
 {% ([properties, before, property]) => {
   property.raws = { ...(property.raws || {}), before };
-  return [].concat(properties, property);
+  return properties.concat(property);
 } %}
 
 property -> qualifiedIdentifier _ "=" _ value


### PR DESCRIPTION
### What issues is this pull request related to?
fix #104

### What changes were made in this pull request?
Concat to existing arrays rather than constructing new ones when parsing