### PR TITLE
ci: fix circleci not running release on main branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -281,5 +281,5 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - main
                 - beta


### PR DESCRIPTION
### What issues is this pull request related to?
None

### What changes were made in this pull request?
circleci should now run release step on `main` branch (was previously looking for `master`, which no longer exists)