### PR TITLE
fix: drop any explicit node 12 support

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -36,8 +36,6 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # tests do not currently succeed on node 12,
-        #   perhaps a sign the engine needs to be updated
         node-version: [14, 16]
     steps:
       - uses: actions/checkout@v2

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     ]
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "snyk": true,
   "packageManager": "yarn@3.1.1"

--- a/packages/@postdfm/ast/package.json
+++ b/packages/@postdfm/ast/package.json
@@ -31,7 +31,7 @@
     "README.md"
   ],
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@postdfm/ast2dfm/package.json
+++ b/packages/@postdfm/ast2dfm/package.json
@@ -34,7 +34,7 @@
     "README.md"
   ],
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@postdfm/dfm2ast/package.json
+++ b/packages/@postdfm/dfm2ast/package.json
@@ -37,7 +37,7 @@
     "README.md"
   ],
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@postdfm/plugin/package.json
+++ b/packages/@postdfm/plugin/package.json
@@ -42,7 +42,7 @@
     "README.md"
   ],
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@postdfm/transform/package.json
+++ b/packages/@postdfm/transform/package.json
@@ -35,7 +35,7 @@
     "README.md"
   ],
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/postdfm/package.json
+++ b/packages/postdfm/package.json
@@ -47,7 +47,7 @@
     "README.md"
   ],
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
### What issues is this pull request related to?
#251

### What changes were made in this pull request?
as mentioned in #251, tests currently fail on node 12 - as such, postdfm is not guaranteed to work
on node 12, so explicitly forcing node 14 as a minimum should be safe

BREAKING CHANGE: node 12 support dropped, minimum version is now node 14
