### PR TITLE
build: fix release.config.cjs to stop using execa

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-jest": "^25.3.0",
     "eslint-plugin-node": "^11.1.0",
-    "execa": "^6.0.0",
     "husky": "^7.0.4",
     "jest": "^27.4.3",
     "jest-junit": "^13.0.0",

--- a/release.config.cjs
+++ b/release.config.cjs
@@ -1,9 +1,12 @@
 const path = require("path");
-const execa = require("execa");
+const { spawnSync } = require("child_process");
 
-const pkgs = execa
-  .commandSync("yarn workspaces list --json")
+const pkgs = spawnSync("yarn", ["workspaces", "list", "--json"], {
+  shell: true,
+  encoding: "utf-8",
+})
   .stdout.split(/[\r\n]+/)
+  .filter(Boolean)
   .map(JSON.parse)
   .filter(({ location }) => location !== ".");
 
@@ -20,8 +23,8 @@ module.exports = {
       "@semantic-release/npm",
       {
         pkgRoot,
-        tarballDir
-      }
+        tarballDir,
+      },
     ]),
     [
       "@semantic-release/github",
@@ -31,17 +34,17 @@ module.exports = {
             tarballDir,
             `${name.replace("@", "").replace("/", "-")}-*.tgz`
           ),
-          label: name
-        }))
-      }
+          label: name,
+        })),
+      },
     ],
     [
       "@semantic-release/git",
       {
         assets: [
-          ["packages/**/package.json", "!**/node_modules/**/package.json"]
-        ]
-      }
-    ]
-  ]
+          ["packages/**/package.json", "!**/node_modules/**/package.json"],
+        ],
+      },
+    ],
+  ],
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3742,23 +3742,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"execa@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "execa@npm:6.0.0"
-  dependencies:
-    cross-spawn: ^7.0.3
-    get-stream: ^6.0.1
-    human-signals: ^3.0.1
-    is-stream: ^3.0.0
-    merge-stream: ^2.0.0
-    npm-run-path: ^5.0.1
-    onetime: ^6.0.0
-    signal-exit: ^3.0.5
-    strip-final-newline: ^3.0.0
-  checksum: c44249edd4d112266ecd95df9eff5657e07a24aa41f6fb34d9b8185db1255231b482b469e2b8837a73cc898a51ef38ca2bab15d78d80c46917adade3e688da7f
-  languageName: node
-  linkType: hard
-
 "exit@npm:^0.1.2":
   version: 0.1.2
   resolution: "exit@npm:0.1.2"
@@ -4171,7 +4154,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"get-stream@npm:^6.0.0, get-stream@npm:^6.0.1":
+"get-stream@npm:^6.0.0":
   version: 6.0.1
   resolution: "get-stream@npm:6.0.1"
   checksum: e04ecece32c92eebf5b8c940f51468cd53554dcbb0ea725b2748be583c9523d00128137966afce410b9b051eb2ef16d657cd2b120ca8edafcf5a65e81af63cad
@@ -4495,13 +4478,6 @@ __metadata:
   version: 2.1.0
   resolution: "human-signals@npm:2.1.0"
   checksum: b87fd89fce72391625271454e70f67fe405277415b48bcc0117ca73d31fa23a4241787afdc8d67f5a116cf37258c052f59ea82daffa72364d61351423848e3b8
-  languageName: node
-  linkType: hard
-
-"human-signals@npm:^3.0.1":
-  version: 3.0.1
-  resolution: "human-signals@npm:3.0.1"
-  checksum: f252a7769c8094a5c9dc6772816bdb417b188820b04c8b42d0fc468e03a0ba905b1dd07afabe9385cc83504af1ccc2b985cd1e4aeeeb8e0029896c5af2e6f354
   languageName: node
   linkType: hard
 
@@ -4854,13 +4830,6 @@ __metadata:
   version: 2.0.1
   resolution: "is-stream@npm:2.0.1"
   checksum: b8e05ccdf96ac330ea83c12450304d4a591f9958c11fd17bed240af8d5ffe08aedafa4c0f4cfccd4d28dc9d4d129daca1023633d5c11601a6cbc77521f6fae66
-  languageName: node
-  linkType: hard
-
-"is-stream@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "is-stream@npm:3.0.0"
-  checksum: 172093fe99119ffd07611ab6d1bcccfe8bc4aa80d864b15f43e63e54b7abc71e779acd69afdb854c4e2a67fdc16ae710e370eda40088d1cfc956a50ed82d8f16
   languageName: node
   linkType: hard
 
@@ -6287,13 +6256,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mimic-fn@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "mimic-fn@npm:4.0.0"
-  checksum: 995dcece15ee29aa16e188de6633d43a3db4611bcf93620e7e62109ec41c79c0f34277165b8ce5e361205049766e371851264c21ac64ca35499acb5421c2ba56
-  languageName: node
-  linkType: hard
-
 "min-indent@npm:^1.0.0":
   version: 1.0.1
   resolution: "min-indent@npm:1.0.1"
@@ -6774,15 +6736,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"npm-run-path@npm:^5.0.1":
-  version: 5.0.1
-  resolution: "npm-run-path@npm:5.0.1"
-  dependencies:
-    path-key: ^4.0.0
-  checksum: 176daed52660122c1c56be3dbc13b8199b5ad29243fc11836856bb9acf9dc333d9c80b1b734212db5e0bc7f0517df0fb6ae59096f193da8ea9844a590e17de9d
-  languageName: node
-  linkType: hard
-
 "npm-user-validate@npm:*":
   version: 1.0.1
   resolution: "npm-user-validate@npm:1.0.1"
@@ -6954,15 +6907,6 @@ __metadata:
   dependencies:
     mimic-fn: ^2.1.0
   checksum: 2478859ef817fc5d4e9c2f9e5728512ddd1dbc9fb7829ad263765bb6d3b91ce699d6e2332eef6b7dff183c2f490bd3349f1666427eaba4469fba0ac38dfd0d34
-  languageName: node
-  linkType: hard
-
-"onetime@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "onetime@npm:6.0.0"
-  dependencies:
-    mimic-fn: ^4.0.0
-  checksum: 0846ce78e440841335d4e9182ef69d5762e9f38aa7499b19f42ea1c4cd40f0b4446094c455c713f9adac3f4ae86f613bb5e30c99e52652764d06a89f709b3788
   languageName: node
   linkType: hard
 
@@ -7276,13 +7220,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"path-key@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "path-key@npm:4.0.0"
-  checksum: 8e6c314ae6d16b83e93032c61020129f6f4484590a777eed709c4a01b50e498822b00f76ceaf94bc64dbd90b327df56ceadce27da3d83393790f1219e07721d7
-  languageName: node
-  linkType: hard
-
 "path-parse@npm:^1.0.6":
   version: 1.0.7
   resolution: "path-parse@npm:1.0.7"
@@ -7375,7 +7312,6 @@ __metadata:
     eslint-config-prettier: ^8.3.0
     eslint-plugin-jest: ^25.3.0
     eslint-plugin-node: ^11.1.0
-    execa: ^6.0.0
     husky: ^7.0.4
     jest: ^27.4.3
     jest-junit: ^13.0.0
@@ -8084,7 +8020,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"signal-exit@npm:^3.0.0, signal-exit@npm:^3.0.2, signal-exit@npm:^3.0.3, signal-exit@npm:^3.0.5":
+"signal-exit@npm:^3.0.0, signal-exit@npm:^3.0.2, signal-exit@npm:^3.0.3":
   version: 3.0.6
   resolution: "signal-exit@npm:3.0.6"
   checksum: b819ac81ba757af559dad0804233ae31bf6f054591cd8a671e9cbcf09f21c72ec3076fe87d1e04861f5b33b47d63f0694b568de99c99cd733ee2060515beb6d5
@@ -8488,13 +8424,6 @@ __metadata:
   version: 2.0.0
   resolution: "strip-final-newline@npm:2.0.0"
   checksum: 69412b5e25731e1938184b5d489c32e340605bb611d6140344abc3421b7f3c6f9984b21dff296dfcf056681b82caa3bb4cc996a965ce37bcfad663e92eae9c64
-  languageName: node
-  linkType: hard
-
-"strip-final-newline@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "strip-final-newline@npm:3.0.0"
-  checksum: 23ee263adfa2070cd0f23d1ac14e2ed2f000c9b44229aec9c799f1367ec001478469560abefd00c5c99ee6f0b31c137d53ec6029c53e9f32a93804e18c201050
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What issues is this pull request related to?
None.

### What changes were made in this pull request?
Fix `release.config.cjs` to stop using `execa`.