### PR TITLE
docs: fix revision used to always be `main`

### DIFF
--- a/typedoc.config.cjs
+++ b/typedoc.config.cjs
@@ -1,9 +1,9 @@
 const path = require("path");
 
-module.exports = (projectName) =>
-  Object.assign({
-    excludePrivate: true,
-    theme: "default",
-    entryPoints: ["src/index.ts"],
-    out: path.resolve(__dirname, "docs", projectName),
-  });
+module.exports = (projectName) => ({
+  excludePrivate: true,
+  theme: "default",
+  entryPoints: ["src/index.ts"],
+  gitRevision: "main",
+  out: path.resolve(__dirname, "docs", projectName),
+});


### PR DESCRIPTION
### What issues is this pull request related to?
None

### What changes were made in this pull request?
Fix git revision used by typedoc to always be `main`.

https://typedoc.org/guides/options/#gitrevision