### PR TITLE
ci: fix deploy-static not compiling first

### DIFF
--- a/.github/workflows/deploy-static.yml
+++ b/.github/workflows/deploy-static.yml
@@ -32,6 +32,7 @@ jobs:
           cache: yarn
 
       - run: yarn install --immutable
+      - run: yarn compile
       - run: yarn docs
       - run: mkdir dist && mv docs dist/
 


### PR DESCRIPTION
### What issues is this pull request related to?
None

### What changes were made in this pull request?
add `yarn compile` to deploy-static action