### PR TITLE
ci: update ci scripts to use latest node version

### DIFF
--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -31,10 +31,10 @@ jobs:
       - uses: actions/checkout@v3
 
         # unlike with ci, we only want the latest version to deploy with
-      - name: setup node.js 16
+      - name: setup node.js
         uses: actions/setup-node@v3.7.0
         with:
-          node-version: 16
+          node-version: latest
           cache: yarn
 
       - run: yarn install --immutable

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -16,11 +16,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      # only need 16 here as none of the steps below test the actual output
-      - name: setup node.js 16
+      # only need latest here as none of the steps below test the actual output
+      - name: setup node.js
         uses: actions/setup-node@v3.7.0
         with:
-          node-version: 16
+          node-version: latest
           cache: yarn
 
       - run: yarn install --immutable
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14, 16]
+        node-version: [16, 18, 20]
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/deploy-static.yml
+++ b/.github/workflows/deploy-static.yml
@@ -28,7 +28,7 @@ jobs:
 
       - uses: actions/setup-node@v3.7.0
         with:
-          node-version: 16
+          node-version: latest
           cache: yarn
 
       - run: yarn install --immutable

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     ]
   },
   "engines": {
-    "node": ">=14.0.0"
+    "node": ">=16.0.0"
   },
   "snyk": true,
   "resolutions": {

--- a/packages/@postdfm/ast/package.json
+++ b/packages/@postdfm/ast/package.json
@@ -31,7 +31,7 @@
     "README.md"
   ],
   "engines": {
-    "node": ">=14.0.0"
+    "node": ">=16.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@postdfm/ast2dfm/package.json
+++ b/packages/@postdfm/ast2dfm/package.json
@@ -34,7 +34,7 @@
     "README.md"
   ],
   "engines": {
-    "node": ">=14.0.0"
+    "node": ">=16.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@postdfm/dfm2ast/package.json
+++ b/packages/@postdfm/dfm2ast/package.json
@@ -37,7 +37,7 @@
     "README.md"
   ],
   "engines": {
-    "node": ">=14.0.0"
+    "node": ">=16.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@postdfm/plugin/package.json
+++ b/packages/@postdfm/plugin/package.json
@@ -42,7 +42,7 @@
     "README.md"
   ],
   "engines": {
-    "node": ">=14.0.0"
+    "node": ">=16.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@postdfm/transform/package.json
+++ b/packages/@postdfm/transform/package.json
@@ -35,7 +35,7 @@
     "README.md"
   ],
   "engines": {
-    "node": ">=14.0.0"
+    "node": ">=16.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/postdfm/package.json
+++ b/packages/postdfm/package.json
@@ -47,7 +47,7 @@
     "README.md"
   ],
   "engines": {
-    "node": ">=14.0.0"
+    "node": ">=16.0.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
### What issues is this pull request related to?
none

### What changes were made in this pull request?
update ci scripts to use latest node version
(some CI scripts now use node 16, 18 and 20)

BREAKING CHANGE: bumped minimum version from 14 to 16